### PR TITLE
fix(build): resolve next-on-pages build failure and recursion

### DIFF
--- a/apps/web-main/package.json
+++ b/apps/web-main/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "pnpm run build:next && npx @cloudflare/next-on-pages --skip-build",
+    "build": "npx @cloudflare/next-on-pages",
     "build:next": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/apps/web-main/vercel.json
+++ b/apps/web-main/vercel.json
@@ -1,0 +1,3 @@
+{
+  "buildCommand": "pnpm run build:next"
+}

--- a/apps/web-prosper/package.json
+++ b/apps/web-prosper/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "pnpm run build:next && npx @cloudflare/next-on-pages --skip-build",
+    "build": "npx @cloudflare/next-on-pages",
     "build:next": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/apps/web-prosper/vercel.json
+++ b/apps/web-prosper/vercel.json
@@ -1,0 +1,3 @@
+{
+  "buildCommand": "pnpm run build:next"
+}

--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,7 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": [".next/**", "dist/**"]
+      "outputs": [".next/**", ".vercel/**", "dist/**"]
     },
     "lint": {
       "cache": false


### PR DESCRIPTION
## Summary
- Fixed recursive build loop in Next.js apps by adding `vercel.json` build command override.
- Streamlined Cloudflare build command to use `npx @cloudflare/next-on-pages` as the primary script.
- Enabled Turborepo caching for `.vercel` output directory.

## Test Plan
- [x] Verified local build for `web-main`: `npx turbo build --filter=web-main`
- [x] Verified local build for `web-prosper`: `npx turbo build --filter=web-prosper`