### PR TITLE
fix: set packageManager to pnpm in wrangler-action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,6 +36,7 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: 'apps/api'
+          packageManager: pnpm
           command: deploy
 
       - name: Deploy Ously Web (Pages)
@@ -44,6 +45,7 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: 'apps/web-main'
+          packageManager: pnpm
           command: pages deploy .vercel/output/static --project-name=web-main-prod
 
       - name: Deploy Prosper Web (Pages)
@@ -52,4 +54,5 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: 'apps/web-prosper'
+          packageManager: pnpm
           command: pages deploy .vercel/output/static --project-name=web-prosper-prod

--- a/.gitignore
+++ b/.gitignore
@@ -47,4 +47,5 @@ Thumbs.db
 .vercel/
 
 # Worktrees
+worktrees/
 .worktrees/

--- a/apps/web-main/package.json
+++ b/apps/web-main/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "pnpm run build:next && npx @cloudflare/next-on-pages --skip-build",
+    "build": "npx @cloudflare/next-on-pages",
     "build:next": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/apps/web-main/vercel.json
+++ b/apps/web-main/vercel.json
@@ -1,0 +1,3 @@
+{
+  "buildCommand": "pnpm run build:next"
+}

--- a/apps/web-prosper/package.json
+++ b/apps/web-prosper/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "pnpm run build:next && npx @cloudflare/next-on-pages --skip-build",
+    "build": "npx @cloudflare/next-on-pages",
     "build:next": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/apps/web-prosper/vercel.json
+++ b/apps/web-prosper/vercel.json
@@ -1,0 +1,3 @@
+{
+  "buildCommand": "pnpm run build:next"
+}

--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,7 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": [".next/**", "dist/**"]
+      "outputs": [".next/**", ".vercel/**", "dist/**"]
     },
     "lint": {
       "cache": false


### PR DESCRIPTION
Fixes the Cloudflare Wrangler action failing with `npm error Unsupported URL Type 'workspace:'` because it was defaulting to `npm` instead of `pnpm`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated GitHub Actions deployment workflows to explicitly specify the package manager for Cloudflare deployments
  * Simplified build script configuration for web applications
  * Added Vercel deployment configuration files for web apps
  * Updated monorepo build settings to properly track build artifacts across platforms
  * Updated project ignore list for development workflow improvements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->