### PR TITLE
fix: move ISSUE comment after YAML frontmatter, delete .prettierignore, update AGENTS.md convention

### DIFF
--- a/.gemini/agents/pr_opener.md
+++ b/.gemini/agents/pr_opener.md
@@ -1,4 +1,3 @@
-<!-- ISSUE_#81 | 2026-05-09 | Add detailed action-log and reviewer notes template to PR opener -->
 ---
 name: pr_opener
 description: Specialized in creating GitHub pull requests with high-quality, summarized descriptions using the 'gh' CLI. Use this when you are ready to submit your changes for review.
@@ -6,6 +5,8 @@ tools:
   - run_shell_command
 model: gemini-3.1-flash-lite-preview
 ---
+
+<!-- ISSUE_#81 | 2026-05-09 | Add detailed action-log and reviewer notes template to PR opener -->
 
 You are the **PR Opener**, a specialized assistant for creating GitHub pull requests. Your goal is to automate the PR creation process while ensuring the description is professional, detailed, and accurately reflects the changes.
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,0 @@
-# YAML-frontmatter agent configs - Prettier mangled the YAML
-.gemini/agents/*.md
-.opencode/agents/*.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,11 +54,11 @@ For every file edited as part of a task, add a comment header at the top of the 
 // ISSUE_#<number> | <YYYY-MM-DD> | <One-line summary of the change>
 ```
 
-For files with YAML frontmatter (`---` delimited), use an HTML comment above the frontmatter:
+For files with YAML frontmatter (`---` delimited), use an HTML comment after the closing frontmatter:
 
 ```
-<!-- ISSUE_#<number> | <YYYY-MM-DD> | <One-line summary of the change> -->
 ---
+<!-- ISSUE_#<number> | <YYYY-MM-DD> | <One-line summary of the change> -->
 ```
 
 This tracks which issue triggered the change, when it happened, and what was done.


### PR DESCRIPTION
## Summary

Fix the File Change Tracking convention so it works with Prettier. The HTML comment before `---` frontmatter was being mangled by Prettier. Moving it after the closing `---` solves this cleanly.

## Changes by File

### `.gemini/agents/pr_opener.md`
- Moved `<!-- ISSUE_#81 ... -->` comment from **before** the opening `---` to **after** the closing `---`
- This prevents Prettier from mangling the YAML frontmatter

### `AGENTS.md`
- Updated Section 0 convention: for YAML frontmatter files, the HTML comment goes **after** the closing frontmatter `---`

### `.prettierignore` (deleted)
- Removed the file entirely — no files need Prettier exclusion now that the convention is fixed

## Commands Executed
- `edit` — pr_opener.md, AGENTS.md
- `rm` — .prettierignore
- `pnpm format --check` — ✅ all files pass
- `pnpm lint` — ✅ 0 errors
- `pnpm build` — ✅ full turbo build passes

## Reviewer Notes
- The HTML comment after `---` is perfectly handled by Prettier — it stays in place and doesn't corrupt the frontmatter
- No other agent configs (.gemini/agents/*.md, .opencode/agents/*.md) have ISSUE comments yet, so no other files needed fixing