### PR TITLE
fix: address PR review feedback - remove redundant ISSUE annotations, fix TODO placement, update header format

### DIFF
--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -63,6 +63,7 @@ This guide defines the architectural standards and coding conventions for the Ou
 
 - **Convention**: All pending work or technical debt MUST be marked with `// TODO(ISSUE-XXX): <description>`.
 - **Requirement**: Every TODO must link to a valid GitHub Issue ID. If an issue doesn't exist, one must be created before adding the comment.
+
 ### 4. File-Level Header Annotation
 
 All source files should include a header annotation with pipe-separated columns. Extend the existing format with 2 additional columns for AI tool and model attribution.


### PR DESCRIPTION
## Summary

Addresses all review feedback from `gemini-code-assist` on PR #121 and updates the file-level tracking header policy.

## Changes

- **`.gemini/styleguide.md`** — Added File-Level Header Annotation section (5-column pipe format: issue, date, description, tool, model). Applied same header to the file itself.
- **`AGENTS.md`** — Updated policy: headers required for **functional changes** (new hooks, backend wiring), NOT for cosmetic/comment-only edits.
- **`apps/api/src/index.ts`, `apps/web-main/app/page.tsx`, `apps/web-prosper/app/page.tsx`, `packages/ui/src/index.ts`** — Removed redundant `// ISSUE_#119` file-level annotations per review feedback.
- **`packages/domain/src/user.ts`** — Extended existing header with tool/model columns: `opencode | deepseek-v4-flash`.
- **`packages/ui/src/components/OuslySidebar.tsx`** — Removed redundant ISSUE annotation and moved `TODO(ISSUE-82)` after all imports to avoid disrupting the import block (per review feedback).